### PR TITLE
Rewrite README and CONTRIBUTING to match current codebase

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -27,19 +27,20 @@ yarn install
 quasar dev        # opens http://localhost:9000
 ```
 
-> Run commands from the repo root (that's where `package.json` lives).
+> Run commands from the repo root (that's where `package.json` lives — this repo *is* the Quasar project root, there's no extra folder to `cd` into).
 
 ## Project structure cheat sheet
 | Path | Purpose |
 | --- | --- |
-| `src/pages/` | Pages (.vue) — the main development area |
+| `src/pages/` | Pages (.vue) — the main development area (12 feature pages) |
 | `src/router/routes.js` | Route registry; must edit when adding a page |
-| `src/store/` | Vuex local state (8 modules), persisted to localStorage |
+| `src/store/` | Vuex local state (7 modules), persisted to localStorage |
 | `src/services/` | Background services, e.g. `newsService.js` |
-| `src/data/` | Static data (`metroData.js`, `restaurantData.json`) |
+| `src/data/` | Static data (`metroData.js`, `restaurantData.json`, `schedules/`) |
 | `src/boot/` | Startup init (axios, i18n) |
 | `tools/` | Python tools (schedule/menu file conversion) — lives at the repo root, so Vite doesn't scan it |
 | `src-capacitor/` | Android / iOS native wrappers and version config |
+| `docs/decisions/` | Write-ups of what changed and why for past refactor/feature tasks — worth skimming the relevant ones before you start |
 
 See the [README](README.en.md) for details.
 
@@ -49,6 +50,7 @@ See the [README](README.en.md) for details.
 - ⚠️ **IMPORTANT: a `[deploy] ` prefix in the commit message triggers an automatic release!**
   - A commit prefixed with `[deploy] ` kicks off a GitHub Action that automatically attempts to build and upload to Google Play / TestFlight.
   - **Do NOT add `[deploy] ` to normal development commits**, to avoid accidental deployments. Add it only when you intend to release (and remember to bump the version first, see below).
+  - This checks the message of whatever commit actually lands on `main`. Merging a PR through the GitHub UI defaults to a merge-commit title like "Merge pull request #...", which won't trigger it — it only fires if you manually edit that merge-commit title to start with `[deploy] `, or commit directly to `main` with a message that does.
 
 ## Adding a new page
 1. Create `XxxPage.vue` in `src/pages/` (with `<template>`, `<script>`, `<style>`).
@@ -77,7 +79,9 @@ yarn format    # auto-format
 ## Changing data
 - **Restaurant data**: edit `src/data/restaurantData.json` (FoodPage).
 - **MRT data**: edit `src/data/metroData.js` (TransportPage).
-- **Schedules / menus**: these are dynamic data living in the **Data** repo (`ClassesSchedule.json`, `menus/`). See the README's [SchedulePage](README.en.md#schedulepage) and [MenuPage](README.en.md#menupage) sections for the workflow, and use the Python tools in `tools/` for conversion.
+- **Schedule data**: edit the three per-grade JSON files under `src/data/schedules/` (`gaoyi_schedules.json`, `gaoer_schedules.json`, `gaosan_schedules.json`). Each class entry has an `id` and a `schedule` (Monday-Friday, each an array of 8 subjects). The `index.js` in the same folder converts these automatically into what the pages need — you shouldn't need to touch `index.js` itself. **This data now lives directly in this repo, not the `Data` repo**, and needs no network request.
+  - ⚠️ `tools/Convert_xlsx_to_json.py` currently outputs a different format than this (see [README known issues](README.en.md#known-issues--todo)) — it can't be used as-is to produce these files. Either hand-format new data to match the existing files, or update the tool first.
+- **Menu data**: this is dynamic data living in the **Data** repo (`menus/` folder). See the README's [MenuPage](README.en.md#menupage) section for the workflow, and use `tools/menu_scraper.py` / `tools/menu_visualizer.py` for conversion.
 
 ## Bumping the version
 Before a release, update the version everywhere (currently **3.1**):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,20 @@ yarn install
 quasar dev        # 開啟 http://localhost:9000
 ```
 
-> 請在 repo 根目錄執行指令（`package.json` 在這裡）。
+> 請在 repo 根目錄執行指令（`package.json` 在這裡；這個repo本身就是Quasar專案根目錄，不需要再往下一層資料夾）。
 
 ## 專案結構速查
 | 路徑 | 用途 |
 | --- | --- |
-| `src/pages/` | 各頁面（.vue），主要開發區 |
+| `src/pages/` | 各頁面（.vue），主要開發區（共 12 個功能頁面） |
 | `src/router/routes.js` | 路由登記處；新增頁面必改 |
-| `src/store/` | Vuex 本機狀態（8 個模組），會持久化到 localStorage |
+| `src/store/` | Vuex 本機狀態（7 個模組），會持久化到 localStorage |
 | `src/services/` | 背景服務，如 `newsService.js` |
-| `src/data/` | 靜態資料（`metroData.js`、`restaurantData.json`） |
+| `src/data/` | 靜態資料（`metroData.js`、`restaurantData.json`、`schedules/`） |
 | `src/boot/` | 啟動初始化（axios、i18n） |
 | `tools/` | Python 工具（課表/菜單轉檔），位於 repo 根目錄，避免被 Vite 掃到 |
 | `src-capacitor/` | Android / iOS 原生包裝與版本設定 |
+| `docs/decisions/` | 過去每個重構/功能任務的「改了什麼、為什麼」說明文件，接手前建議先掃過相關的 |
 
 詳細說明見 [README](README.md)。
 
@@ -49,6 +50,7 @@ quasar dev        # 開啟 http://localhost:9000
 - ⚠️ **重要：commit message 開頭的 `[deploy] ` 會觸發自動上架！**
   - 加上 `[deploy] ` 前綴的 commit 會啟動 GitHub Action，自動嘗試 build 並上傳到 Google Play / TestFlight。
   - **一般開發 commit 請勿加 `[deploy] `**，以免誤觸發部署。確定要發版時才加（並記得先改版本號，見下）。
+  - 這個檢查看的是「實際 push 到 `main` 的那個 commit」的訊息。用GitHub網頁介面合併PR時，預設的merge commit標題是「Merge pull request #...」，不會誤觸發；只有你自己手動把merge commit標題改成`[deploy] `開頭，或是直接commit到main且訊息以`[deploy] `開頭，才會觸發上架。
 
 ## 新增一個頁面
 1. 在 `src/pages/` 新增 `XxxPage.vue`（含 `<template>`、`<script>`、`<style>`）。
@@ -77,7 +79,9 @@ yarn format    # 自動排版
 ## 資料的修改
 - **餐廳資料**：改 `src/data/restaurantData.json`（FoodPage）。
 - **北捷資料**：改 `src/data/metroData.js`（TransportPage）。
-- **課表 / 菜單**：屬於動態資料，放在 **Data** repo（`ClassesSchedule.json`、`menus/`），流程見 README 的 [SchedulePage](README.md#schedulepage-課表) 與 [MenuPage](README.md#menupage-熱食部) 說明，並可用 `tools/` 的 Python 工具轉檔。
+- **課表資料**：改 `src/data/schedules/` 底下依年級分開的三個 JSON（`gaoyi_schedules.json`、`gaoer_schedules.json`、`gaosan_schedules.json`），格式是「每個班一個 `id` + 一份 `schedule`（週一到週五，每天 8 節課的科目陣列）」，同資料夾的 `index.js` 會自動轉成頁面要的格式，不需要手動改 `index.js`。**這份資料現在直接放在這個repo裡，不再放 Data repo**，也不需要網路請求。
+  - ⚠️ `tools/Convert_xlsx_to_json.py` 目前輸出的格式跟這裡不一樣（見 [README 已知問題](README.md#已知問題與待辦)），還不能直接拿來產生這些檔案，要嘛手動比照現有檔案格式整理，要嘛先更新這個工具。
+- **菜單資料**：屬於動態資料，放在 **Data** repo（`menus/` 資料夾）。流程見 README 的 [MenuPage](README.md#menupage-熱食部) 說明，可用 `tools/` 的 `menu_scraper.py`、`menu_visualizer.py` 轉檔。
 
 ## 改版本號
 發版前要同步更新版本（目前為 **3.1**）：

--- a/README.en.md
+++ b/README.en.md
@@ -2,7 +2,7 @@
 
 **Language / 語言:** [中文](README.md) ｜ English (this page)
 
-> Current version: **3.1** (the `versionName` in `src-capacitor/android/app/build.gradle`)　|　Docs last updated: 2026-06
+> Current version: **3.1** (the `versionName` in `src-capacitor/android/app/build.gradle`)　|　Docs last updated: 2026-07
 >
 > ⚠️ Note: the `version` field in `package.json` is still `3.0.1`, which is out of sync with the real version. The source of truth for the version is Android's `build.gradle` and iOS's `project.pbxproj` (see [Development](#development)).
 
@@ -10,7 +10,7 @@
 1. [What is CK APP?](#what-is-ck-app)
 2. [Architecture](#architecture)
 3. [Pages / Features](#pages--features)
-4. [Store, i18n & other infrastructure](#store-i18n--other-infrastructure)
+4. [Store & other infrastructure](#store--other-infrastructure)
 5. [Known issues & TODO](#known-issues--todo)
 6. [Development](#development)
 7. [Contributing](#contributing)
@@ -19,12 +19,13 @@
 CK APP is an app built by Diego Peng and Kimi Yang, 77th-cohort students of Chien Kuo High School (建中), during the summer of 2024. Its goal is to help every CK student deal with the everyday problems of school life. Since launching on both iOS and Android in September 2024, CK APP accumulated 2,080 downloads by September 2025. We hope CK APP can keep helping all future CK students.
 
 ## Architecture
-CK APP's main code and data both live on GitHub, across two repos — `CK_app` and `Data` (there's actually a third repo, `Proxy`, but it's deprecated — it was the old Heroku code).
+CK APP's main code and data both live on GitHub, across two repos — `CK_app` and `Data` (there's actually a third repo, `Proxy`, but it's deprecated — it was the old Heroku code). This repo (`CK_app`) *is* the Quasar project root — `package.json`, `src/`, etc. all live directly at the repo root, so there's no extra folder to `cd` into after cloning.
 
 ### Data
-`Data` holds data that needs to change dynamically so CK APP can read it directly. Currently the data in active use is:
-- `menus`: folder holding the cafeteria (熱食部) menus
-- `ClassesSchedule.json`: class schedules for the whole school
+`Data` holds data that needs to change dynamically so CK APP can read it directly. The only thing still actively used from it is:
+- `menus`: folder holding the cafeteria (熱食部) menus (see [MenuPage](#menupage) below)
+
+> Class schedule data (the old `ClassesSchedule.json`) used to live here too, but the school stopped providing that source for a while over privacy concerns, which broke this mechanism. After obtaining fresh class-schedule data, we switched to bundling it directly inside the `CK_app` repo itself (`src/data/schedules/`), so it no longer depends on the `Data` repo or a network request at all — see [SchedulePage](#schedulepage) below for details.
 
 ### CK_app
 `CK_app` is the main CK APP codebase, written with the Quasar Framework — essentially HTML, CSS, and JavaScript. We chose Quasar because it can output both Android and iOS apps from one codebase, so we don't have to write two separate versions.
@@ -37,36 +38,40 @@ Commonly used files / folders:
 - **src**
 	- **boot**: initialization code loaded when the app starts
 		- `axios.js`: configures axios (HTTP requests)
-		- `firebase.js`: initializes Firebase
 		- `i18n.js`: initializes internationalization (vue-i18n)
 	- **data**
 		- `metroData.js`: Taipei MRT station and line info
 		- `restaurantData.json`: FoodPage restaurant data (we considered moving it to `Data` for dynamic updates, but for some reason the Android build couldn't read it `==`)
+		- `schedules/`: class schedules for the whole school (three raw grade JSON files plus an `index.js` that converts them into the shape the pages need) — see [SchedulePage](#schedulepage)
 	- **i18n**: localization strings (currently only `en-US`, not yet fully used)
-	- **pages**: the heart of CK APP — most development happens here (13 pages total, see [Pages / Features](#pages--features))
+	- **pages**: the heart of CK APP — most development happens here (12 pages total, see [Pages / Features](#pages--features))
 	- **components / layouts**: shared components (e.g. `EssentialLink.vue`) and layouts (`MainLayout.vue`)
 	- **router**
 		- `routes.js`: register any new page here so other pages can link to it
 	- **services**
 		- `newsService.js`: auto-refreshes NewsPage data every 2 minutes
-	- **store**: pages mutate local data through here — very important (see the [Store section](#store-i18n--other-infrastructure))
+	- **store**: pages mutate local data through here — very important (see the [Store section](#store--other-infrastructure))
 	- **utils**
 		- `xmlUtils.js`: helper for parsing the school website's XML
 - **tools** (lives at the repo root, alongside `src/` — not part of the Vite project)
-	- `Convert_xlsx_to_json.py`: converts the academic-office schedule file (.xls) into JSON; usage notes are inside the file
+	- `Convert_xlsx_to_json.py`: converts the academic-office schedule file (.xls) into JSON; usage notes are inside the file (⚠️ its output format no longer matches what `src/data/schedules/` uses — see [Known issues](#known-issues--todo))
 	- `menu_scraper.py`: (see the MenuPage section)
 	- `menu_visualizer.py`: auto-converts the cafeteria menu into image files
 
-Besides GitHub, we also use Firebase to store user data, plus the [official website](https://ckapp-tw.web.app/) (built & maintained by Ian Wen of the 78th cohort), the official Gmail (ckappofficial@gmail.com), and the [official Instagram account](https://www.instagram.com/ckappofficial/).
+Besides GitHub, we also have the [official website](https://ckapp-tw.web.app/) (built & maintained by Ian Wen of the 78th cohort), the official Gmail (ckappofficial@gmail.com), and the [official Instagram account](https://www.instagram.com/ckappofficial/). (We used to store logged-in users' data in Firebase, but the login feature and Firebase have both been fully removed — see [Known issues & TODO](#known-issues--todo).)
 
 ## Pages / Features
-CK APP currently has **13 pages** (all registered in `src/router/routes.js`), all written with the Quasar Framework. A Quasar `.vue` file has three parts — `<template>`, `<script>`, `<style>` — i.e. HTML, JavaScript, and CSS.
+CK APP currently has **12 pages** (all registered in `src/router/routes.js`), all written with the Quasar Framework. A Quasar `.vue` file has three parts — `<template>`, `<script>`, `<style>` — i.e. HTML, JavaScript, and CSS.
 
 ### HomePage
 Besides the six page buttons, the home page shows three dynamic pieces of info: the current class, today's to-dos, and pinned school-website content.
 
 ### SchedulePage
-The schedule page has two buttons that fetch `ClassesSchedule.json`: set class & reload data.
+Chien Kuo's class schedules (grades 1-3, 81 classes total, 8 periods a day) are bundled as three JSON files in `src/data/schedules/` (`gaoyi_schedules.json`, `gaoer_schedules.json`, `gaosan_schedules.json`). An `index.js` in the same folder converts them into the shape the page needs, and also exports the class list (`CLASS_OPTIONS`) and a "which period is it right now" helper (`getCurrentPeriodName`) that checks the real start/end time of each period, including the lunch gap.
+
+The "set class" and refresh buttons on the page just switch/reload this local data — no network connection needed. Any subjects/colors/notes the user has customized still live in `localStorage` (see [Store](#store--other-infrastructure)) and won't be overwritten by the bundled data unless the user taps refresh.
+
+> This mechanism was disabled in October 2025 over school privacy concerns (replaced with a "please enter it yourself" message), and was restored in July 2026. For the full reasoning and decision process, see [`docs/decisions/feature-schedule-data-import/`](docs/decisions/feature-schedule-data-import/restore-schedule-data-import.md).
 
 ### TodoPage
 Split into two parts: a monthly calendar & a to-do list. How it works is a bit complicated, but you shouldn't need to touch it, so we won't explain it :D
@@ -106,22 +111,19 @@ Embeds the external souvenir store [`souvenir.cksc.tw/auth`](https://souvenir.ck
 A small utility page: the user enters one option per line, and on button press it randomly picks one for you. Pure front-end, no external data.
 
 ### SettingsPage
-Pretty self-explanatory.
+Pretty self-explanatory. Lets you switch class (which feeds SchedulePage), toggle which sections show on the home page, and customize the toolbar.
 
 ### AboutPage
 Shows version info (currently 3.1). Remember to bump the version (see [Development](#development)). We should add developer bios later.
 
-### LoginPage
-The sign-up / login feature should probably be removed in the future. Currently we dump user data into Firebase, but CK APP now seems barely able to access Firebase — we suspect it's because so many users uploaded data that even the admin console lags badly when trying to view it.
+> There's also `ErrorNotFound.vue` as the 404 page for unmatched routes (not counted among the 12 feature pages).
 
-> There's also `ErrorNotFound.vue` as the 404 page for unmatched routes (not counted among the 13 feature pages).
-
-## Store, i18n & other infrastructure
+## Store & other infrastructure
 
 ### Store (Vuex)
 `src/store/` is the app's local-state hub and is **very important**. Pages read and write through it, and `localStoragePlugin.js` automatically syncs it to the browser's / device's `localStorage`, so data persists across app restarts.
 
-There are currently 8 modules (`src/store/modules/`):
+There are currently 7 modules (`src/store/modules/`):
 
 | Module | Feature |
 | --- | --- |
@@ -131,7 +133,6 @@ There are currently 8 modules (`src/store/modules/`):
 | `schedule` | Class schedule and the currently set class (SchedulePage) |
 | `todo` | Calendar and to-do items (TodoPage) |
 | `food` | FoodPage restaurant-related state |
-| `account` | User account / login state (LoginPage) |
 | `settings` | App settings (SettingsPage) |
 
 Also:
@@ -145,13 +146,15 @@ The project has an internationalization scaffold via `vue-i18n` (`src/boot/i18n.
 The TODOs / known bugs scattered across the page descriptions, collected here so whoever takes over can see them at a glance:
 
 - [ ] **Version out of sync**: `package.json` says `3.0.1` while the shipped version is `3.1`. Consider unifying the source of truth.
+- [ ] **Schedule conversion tool doesn't match the new data format**: `tools/Convert_xlsx_to_json.py` still outputs the old format (a single `ProcessedClassesSchedule.json`, originally meant to be pasted into the `Data` repo by hand), but SchedulePage now reads three per-grade JSON files with a different shape from `src/data/schedules/`. Next time the schedule needs updating for a new semester, this tool needs to be updated (or rewritten) to produce the new format directly.
 - [ ] **MenuPage date off-by-one**: MenuPage sometimes counts the Monday date one day early; currently worked around by having `menu_visualizer` output an extra filename. Root cause unfixed.
 - [ ] **FoodPage hours hack**: to keep marker colors correct, some shops' hours are written as past 24:00; overnight hours should be handled properly later.
 - [ ] **restaurantData can't be made dynamic**: we wanted to move it to the `Data` repo for dynamic updates, but the Android build fetches the data yet fails to draw markers. Needs investigation.
 - [ ] **TransportPage geolocation**: auto-detecting the user's location for nearest stations was shelved due to permission and implementation cost.
-- [ ] **LoginPage / Firebase**: the login feature should be removed in the future; Firebase is hard to access due to data volume.
 - [ ] **i18n not realized**: the scaffold exists but most UI text is hard-coded Chinese.
 - [ ] **AboutPage**: could add developer bios.
+
+> The login feature and Firebase were fully removed as part of the [Phase 3 refactor](docs/decisions/phase-3-remove-login/), so they're no longer on this list. For more on past refactoring (including security fixes and cleanup), see [`docs/refactoring-plan.md`](docs/refactoring-plan.md) and the per-task write-ups under [`docs/decisions/`](docs/decisions/).
 
 ## Development
 ### Simulating in a browser on your computer
@@ -173,6 +176,8 @@ The TODOs / known bugs scattered across the page descriptions, collected here so
 [![Build (& Deploy to TestFlight) iOS APP](https://github.com/CK-APP-Org/CK_app/actions/workflows/build_ios.yml/badge.svg)](https://github.com/CK-APP-Org/CK_app/actions/workflows/build_ios.yml)
 1. Bump the version in `src-capacitor\ios\App\App.xcodeproj\project.pbxproj` (`CURRENT_PROJECT_VERSION` & `MARKETING_VERSION`) (both debug & release)
 2. (a) Run the GitHub Action "Deploy iOS App to TestFlight"; or (b) prefix the commit message with `[deploy] ` to automatically attempt upload & release
+
+> ⚠️ Both of these GitHub Actions automatically **build** on every push to `main` that touches the code (but that alone doesn't publish anything). Actually triggering a **release** (uploading to Google Play / TestFlight) needs one of: manually clicking "Run workflow" on the Actions tab, or having the commit that lands on `main` (e.g. a PR's merge commit) start its message with `[deploy] `. GitHub's default merge-commit title doesn't do that, so a normal PR merge won't accidentally trigger a release.
 
 ## Contributing
 Contributions and handoffs are welcome! Please read the [Contributing Guide (CONTRIBUTING.en.md)](CONTRIBUTING.en.md) before opening a PR.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **語言 / Language：** 中文（本頁） ｜ [English](README.en.md)
 
-> 當前版本：**3.1**（`src-capacitor/android/app/build.gradle` 的 `versionName`）　｜　文件最後更新：2026-06
+> 當前版本：**3.1**（`src-capacitor/android/app/build.gradle` 的 `versionName`）　｜　文件最後更新：2026-07
 >
 > ⚠️ 注意：`package.json` 的 `version` 欄位目前仍是 `3.0.1`，與實際版本不同步。版本的真正來源是 Android 的 `build.gradle` 與 iOS 的 `project.pbxproj`（見[開發說明](#開發說明)）。
 
@@ -10,7 +10,7 @@
 1. [CK APP是什麼？](#ck-app是什麼)
 2. [CK APP架構介紹](#ck-app架構介紹)
 3. [頁面/功能介紹](#頁面功能介紹)
-4. [Store、i18n 與其他基礎建設](#storei18n-與其他基礎建設)
+4. [Store 與其他基礎建設](#store-與其他基礎建設)
 5. [已知問題與待辦](#已知問題與待辦)
 6. [開發說明](#開發說明)
 7. [貢獻](#貢獻)
@@ -19,12 +19,13 @@
 CK APP是建中第77屆學生彭可翰和楊晨諺於2024年暑假所開發的應用程式，目的是幫助所有建中生解決生活中遇到的大小困難。CK APP自從2024年9月在iOS和Android雙平台上架至2025年9月共累積2080次下載。我們期許CK APP能夠持續幫助未來的所有建中生。
 
 ## CK APP架構介紹
-CK APP的主要程式和資料皆位於GitHub，其共有兩個repo——CK_app和Data (其實有第三個repo Proxy，但他現在是廢棄狀態，為過去Heroku之程式)。
+CK APP的主要程式和資料皆位於GitHub，其共有兩個repo——CK_app和Data (其實有第三個repo Proxy，但他現在是廢棄狀態，為過去Heroku之程式)。這個repo（`CK_app`）本身就是Quasar專案的根目錄——`package.json`、`src/`等都直接在repo根目錄下，clone下來後不需要再往下一層資料夾。
 
 ### Data
-Data為存放需動態改動之資料，讓CK APP可以直接讀取。其中目前有被利用的資料為
-- menus: 存放熱食部菜單的資料夾
-- ClassesSchedule.json: 全校班級之課表
+Data為存放需動態改動之資料，讓CK APP可以直接讀取。目前實際使用中的只剩：
+- menus: 存放熱食部菜單的資料夾（見下方 [MenuPage](#menupage-熱食部) 說明）
+
+> 課表資料（原本的 `ClassesSchedule.json`）過去也放在這裡，但校方一度基於隱私權停止提供資料來源，導致這個機制停擺了一段時間。後來取得新的班級課表資料後，我們改成直接把資料打包進 `CK_app` 這個repo本身（`src/data/schedules/`），不再依賴 Data repo或外部網路請求——細節見下方 [SchedulePage](#schedulepage-課表) 說明。
 
 ### CK_app
 CK_app為CK APP的主體程式，語言是Quasar Framework，本質上為HTML、CSS和JavaScript。當初選用Quasar是因為可以輸出成Android和iOS的app，不需寫兩個不同版本。
@@ -37,36 +38,40 @@ CK_app為CK APP的主體程式，語言是Quasar Framework，本質上為HTML、
 - **src**
 	- **boot**: App 啟動時載入的初始化程式
 		- axios.js: 設定 axios（HTTP 請求）
-		- firebase.js: 初始化 Firebase
 		- i18n.js: 初始化多語系（vue-i18n）
 	- **data**
 		- metroData.js: 北捷站點和路線資訊
 		- restaurantData.json: FoodPage餐廳資料 (有想過丟到Data，才可以動態改動，但這樣Android版不知道為什麼無法讀取資料\==)
+		- schedules/: 全校班級課表（高一/高二/高三三個原始 JSON + 一個 `index.js` 把它們轉成頁面要的格式），見 [SchedulePage](#schedulepage-課表)
 	- **i18n**: 多語系字串（目前僅有 `en-US`，尚未真正全面使用）
-	- **pages**: CK APP的核心，大部分的開發工作會在這裡進行（共 13 個頁面，見[頁面/功能介紹](#頁面功能介紹)）
+	- **pages**: CK APP的核心，大部分的開發工作會在這裡進行（共 12 個頁面，見[頁面/功能介紹](#頁面功能介紹)）
 	- **components / layouts**: 共用元件（如 `EssentialLink.vue`）與版型（`MainLayout.vue`）
 	- **router**
 		- routes.js: 如果有新增頁面要去這裡登記，才可以從其他頁面連結過去
 	- **services**
 		- newsService.js: 讓NewsPage每隔2分鐘自動刷新資料
-	- **store**: 頁面會透過這裡更動本機資料，非常重要（見 [Store 章節](#storei18n-與其他基礎建設)）
+	- **store**: 頁面會透過這裡更動本機資料，非常重要（見 [Store 章節](#store-與其他基礎建設)）
 	- **utils**
 		- xmlUtils.js: 解析校網 XML 的工具
 - **tools**（位於 repo 根目錄，與 `src/` 同層，非 Vite 專案的一部分）
-	- Convert_xlsx_to_json.py: 把教務處課表檔(.xls)轉成json，使用說明在檔案裡
+	- Convert_xlsx_to_json.py: 把教務處課表檔(.xls)轉成json，使用說明在檔案裡（⚠️ 輸出格式目前跟 `src/data/schedules/` 用的格式不一致，見[已知問題](#已知問題與待辦)）
 	- menu_scraper.py: (見 MenuPage 說明)
 	- menu_visualizer.py: 將熱食部菜單自動轉成圖檔
 
-除了GitHub外，我們也有用Firebase儲存使用者資料，以及[官方網站](https://ckapp-tw.web.app/) (由 78屆的Ian Wen開發管理)、官方gmail(ckappofficial@gmail.com)和[官方IG帳號](https://www.instagram.com/ckappofficial/)。
+除了GitHub外，我們也有[官方網站](https://ckapp-tw.web.app/) (由 78屆的Ian Wen開發管理)、官方gmail(ckappofficial@gmail.com)和[官方IG帳號](https://www.instagram.com/ckappofficial/)。（過去也曾用Firebase儲存登入使用者的資料，但登入功能與Firebase已完全移除，見[已知問題與待辦](#已知問題與待辦)。）
 
 ## 頁面/功能介紹
-CK APP目前共有 **13 個頁面**（皆於 `src/router/routes.js` 登記），皆由Quasar Framework寫成。Quasar的檔案(.vue)分為三個部分——\<template>、\<script>、\<style>，即HTML、Javascript和CSS。
+CK APP目前共有 **12 個頁面**（皆於 `src/router/routes.js` 登記），皆由Quasar Framework寫成。Quasar的檔案(.vue)分為三個部分——\<template>、\<script>、\<style>，即HTML、Javascript和CSS。
 
 ### HomePage (首頁)
 除了六個頁面的按鈕外，首頁還包含三個動態資訊：目前課程、今日待辦事項、釘選校網內容。
 
 ### SchedulePage (課表)
-課表有兩個按鈕會去抓ClassesSchedule.json的資料：設定班級&重新載入資料。
+建中的課表（含高一、高二、高三共81個班級、每天8節課）打包成三個 JSON 檔放在 `src/data/schedules/`（`gaoyi_schedules.json`、`gaoer_schedules.json`、`gaosan_schedules.json`），由同資料夾的 `index.js` 轉成頁面要的格式，並提供班級清單（`CLASS_OPTIONS`）與「目前是第幾節課」的判斷（`getCurrentPeriodName`，會對照各節課真實的上下課時間，包含午休空檔）。
+
+頁面上「設定班級」和重新整理按鈕會直接切換/重讀本機資料，不需要網路連線。使用者自訂的科目、顏色、備註仍會存在 `localStorage`（見 [Store 章節](#store-與其他基礎建設)），不會被內建課表資料覆蓋，除非手動點重新整理。
+
+> 這個機制在2025年10月一度因校方隱私考量而停用（改成「請自行輸入」），2026年7月才恢復——詳細原因與決策過程見 [`docs/decisions/feature-schedule-data-import/`](docs/decisions/feature-schedule-data-import/restore-schedule-data-import.md)。
 
 ### TodoPage (行事曆)
 行事曆頁面分為兩個部分：月曆&待辦。詳細運作方式有點複雜，但應該不用改所以就不解釋了:D
@@ -106,22 +111,19 @@ YouBike部分，我們分別讀取[台北市](https://tcgbusfs.blob.core.windows
 小工具頁：使用者每行輸入一個選項，按下按鈕後隨機幫你選一個。純前端、無外部資料。
 
 ### SettingsPage
-滿直觀的。
+滿直觀的。可以切換班級（會連動 SchedulePage）、調整首頁要顯示哪些區塊、自訂工具列。
 
 ### AboutPage
 顯示版本資訊（目前為 3.1）。版本要記得改（見[開發說明](#開發說明)）。之後應該要增加開發者介紹。
 
-### LoginPage
-註冊/登入的功能未來應該要拔掉。目前我們的做法是把使用者資料丟到Firebase，但現在CK APP好像不太能存取Firebase，我們推測是因為太多使用者上傳資料，連後臺想去Firebase看資料都會卡到爆。
+> 另外還有 `ErrorNotFound.vue` 作為找不到路由時的 404 頁（不算在 12 個功能頁面內）。
 
-> 另外還有 `ErrorNotFound.vue` 作為找不到路由時的 404 頁（不算在 13 個功能頁面內）。
-
-## Store、i18n 與其他基礎建設
+## Store 與其他基礎建設
 
 ### Store（Vuex）
 `src/store/` 是 App 的本機狀態中心，**非常重要**。各頁面透過它讀寫資料，並由 `localStoragePlugin.js` 自動同步到瀏覽器 / 裝置的 `localStorage`，所以資料在重開 App 後仍會保留。
 
-目前共有 8 個模組（`src/store/modules/`）：
+目前共有 7 個模組（`src/store/modules/`）：
 
 | 模組 | 對應功能 |
 | --- | --- |
@@ -131,7 +133,6 @@ YouBike部分，我們分別讀取[台北市](https://tcgbusfs.blob.core.windows
 | `schedule` | 班級課表與目前設定的班級（SchedulePage） |
 | `todo` | 行事曆與待辦事項（TodoPage） |
 | `food` | FoodPage 餐廳相關狀態 |
-| `account` | 使用者帳號 / 登入狀態（LoginPage） |
 | `settings` | App 設定（SettingsPage） |
 
 其他：
@@ -145,13 +146,15 @@ YouBike部分，我們分別讀取[台北市](https://tcgbusfs.blob.core.windows
 把散落在各頁說明裡的 TODO / 已知 bug 集中如下，方便接手的人一眼看到：
 
 - [ ] **版本號不同步**：`package.json` 為 `3.0.1`，實際上架版本為 `3.1`。可考慮統一來源。
+- [ ] **課表轉檔工具與新資料格式不一致**：`tools/Convert_xlsx_to_json.py` 輸出的是舊格式（單一 `ProcessedClassesSchedule.json`，原本是要手動貼到 Data repo），但 SchedulePage 現在讀的是 `src/data/schedules/` 底下三份依年級分開、形狀也不同的 JSON。未來要換學期課表時，這個工具需要先更新（或重寫）才能直接產生新格式的檔案。
 - [ ] **MenuPage 日期 off-by-one**：MenuPage 有時把週一日期往前算一天；目前靠 `menu_visualizer` 多輸出一份檔名迴避，根因尚未修。
 - [ ] **FoodPage 營業時間 hack**：為了圖標顏色正常，部分店家時間寫成超過 24 點，未來應正規化處理跨夜營業。
 - [ ] **restaurantData 無法動態化**：想搬到 Data repo 動態更新，但 Android 版抓得到資料卻畫不出圖標，待查。
 - [ ] **TransportPage 定位功能**：原本想自動偵測使用者位置找最近站點，因權限與實作成本暫時放棄。
-- [ ] **LoginPage / Firebase**：登入功能未來應移除；Firebase 因資料量過大而難以存取。
 - [ ] **i18n 尚未落實**：骨架已有但介面文字多為寫死中文。
 - [ ] **AboutPage**：可加入開發者介紹。
+
+> 登入功能與 Firebase 已經在 [Phase 3 重構](docs/decisions/phase-3-remove-login/) 中整個移除了，不再是待辦事項。想了解過去重構的細節（含安全性修正、程式碼整理），可以看 [`docs/refactoring-plan.md`](docs/refactoring-plan.md) 與 [`docs/decisions/`](docs/decisions/) 底下各任務的說明文件。
 
 ## 開發說明
 ### 在電腦以網頁模擬
@@ -173,6 +176,8 @@ YouBike部分，我們分別讀取[台北市](https://tcgbusfs.blob.core.windows
 [![Build (& Deploy to TestFlight) iOS APP](https://github.com/CK-APP-Org/CK_app/actions/workflows/build_ios.yml/badge.svg)](https://github.com/CK-APP-Org/CK_app/actions/workflows/build_ios.yml)
 1. 在 `src-capacitor\ios\App\App.xcodeproj\project.pbxproj` 改版本 (`CURRENT_PROJECT_VERSION` & `MARKETING_VERSION`) (debug & release 都要)
 2. (a) 執行 Github Action - Deploy iOS App to TestFlight；或 (b) 在commit時commit message前加入`[deploy] `，將自動嘗試上傳&上架
+
+> ⚠️ 這兩個 GitHub Action 都會在push到 `main` 且改到程式碼時自動**build**（但不會上架）。真正觸發**上架**（送到 Google Play / TestFlight）需要滿足其中一個條件：手動在 GitHub Actions 頁面點「Run workflow」，或是讓push到 `main` 的那個commit（例如merge PR時的merge commit）訊息開頭是`[deploy] `。合併PR時GitHub預設不會這樣命名merge commit，所以一般merge PR不會不小心觸發上架。
 
 ## 貢獻
 歡迎接手與貢獻！提交 PR 前請先閱讀 [貢獻指南 (CONTRIBUTING.md)](CONTRIBUTING.md)。


### PR DESCRIPTION
## Summary
Total rewrite of `README.md`, `README.en.md`, `CONTRIBUTING.md`, `CONTRIBUTING.en.md` to fix accumulated drift from reality:
- **Removed stale content**: the entire LoginPage section, the `account` Vuex module row, and `boot/firebase.js` — all removed in the Phase 3 refactor but never fully scrubbed from the docs. Page count corrected 13 → 12, store module count 8 → 7.
- **Rewrote SchedulePage's description** to match this branch's change: schedule data is now bundled locally in `src/data/schedules/` instead of fetched from the (privacy-disabled) `Data` repo. Updated the `Architecture` → `Data` section and `CONTRIBUTING`'s "Changing data" section to match.
- **New known issue documented**: `tools/Convert_xlsx_to_json.py`'s output format no longer matches the new `src/data/schedules/` shape — flagged so whoever next updates the schedule for a new semester doesn't get surprised.
- **Clarified the `[deploy]` release mechanism**: spelled out that merging a PR normally does *not* trigger a Google Play/TestFlight release (the default merge-commit title doesn't start with `[deploy] `) — this wasn't documented anywhere before, despite the docs warning about the footgun.
- Added a `docs/decisions/` pointer in both docs so future contributors can find the "why" behind past changes.

## Why this is stacked on #20
This branch is based on `feature/schedule-data-import` (#20) because the SchedulePage/Data-repo rewrite describes code that only exists on that branch. **Merge #20 first** (or merge this PR into that branch) — merging this into `main` before #20 would make the docs describe code that isn't there yet.

## Test plan
- [x] Grepped all 4 files for leftover stale references (LoginPage, account module, firebase.js, old page/module counts) — none found.
- [x] Verified both linked `docs/decisions/` paths exist.
- [x] `npm run lint` clean.
- [ ] Not a code change — no functional testing applicable.